### PR TITLE
reset managed object context before removing persistent store to fix …

### DIFF
--- a/ACECoreDataManager/ACECoreDataManager.m
+++ b/ACECoreDataManager/ACECoreDataManager.m
@@ -327,6 +327,8 @@
                                                     name:NSManagedObjectContextDidSaveNotification
                                                   object:nil];
     
+    [self.managedObjectContext reset];
+
     NSError *error;
     if (![self.persistentStoreCoordinator removePersistentStore:self.persistentStore error:&error]) {
         [self handleError:error];


### PR DESCRIPTION
We have a crash in ACECoreDataManager.m file and Line #331 while doing logout. We have created ticket for it. 

  The crash is happening in deleteContext method and saying ‘Object's persistent store is not reachable from this NSManagedObjectContext's coordinator’
 
I tried to find out the reason for it but could not found any. So I tried resetting managedObjectContext before removing persistent store and it fixed the issue.
